### PR TITLE
add cypress testing for iterations 1+2

### DIFF
--- a/cypress/e2e/main.cy.js
+++ b/cypress/e2e/main.cy.js
@@ -1,12 +1,126 @@
 // Mock data to use for testing:
-// import posters from '../fixtures/movie_posters.json' (we've added mock data to this file for you!)
+import posters from '../fixtures/movie_posters.json' // (we've added mock data to this file for you!)
 // import details from '../fixtures/movie_details.json' (you will need to add your own mock data to this file!)
 
-describe('Main Page', () => {
-  it('displays title on page load', () => {
-    // hint: you'll want to add an intercept here if you are making a network request on page load!
+describe('Movie Posters', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies', { statusCode: 200, body: posters })
+    .as('fetchMovies')
+
     cy.visit('http://localhost:3000/')
-    .get('h1')
+
+    cy.wait('@fetchMovies')
+  })
+
+  it('has a title', () => {
+    cy.get('h1')
     .contains('rancid tomatillos')
+  })
+
+  it('has a collection of movies', () => {
+    cy.get('.MoviesContainer')
+    .should('exist')
+    .and('be.visible')
+    .and('have.length', 1)
+  })
+
+  it('has four posters total', () => {
+    cy.get('.MoviesContainer')
+    .children()
+    .should('have.length', 4)
+  })
+
+  it('has correct details for the first poster', () => {
+    const firstPoster = posters[0]
+
+    cy.get('.MoviesContainer .MoviePoster:first')
+      .within(() => {
+        cy.get('img')
+        .should('be.visible')
+        .and('have.attr', 'src', firstPoster.poster_path)
+        .and('have.attr', 'alt', `${firstPoster.title} poster`)
+
+        cy.get('.VoteCount')
+        .should('contain', firstPoster.vote_count)
+      })
+  })
+
+
+  it('has correct details for the last poster', () => {
+    const lastPoster = posters[3]
+
+    cy.get('.MoviesContainer .MoviePoster:last')
+      .within(() => {
+        cy.get('img')
+        .should('be.visible')
+        .and('have.attr', 'src', lastPoster.poster_path)
+        .and('have.attr', 'alt', `${lastPoster.title} poster`)
+
+        cy.get('.VoteCount')
+        .should('contain', lastPoster.vote_count)
+      })
+  })
+})
+
+describe('Voting Updates', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies', { statusCode: 200, body: posters })
+    .as('fetchMovies')
+
+    cy.visit('http://localhost:3000/')
+
+    cy.wait('@fetchMovies')
+  })
+
+  it('correctly increments movie vote count when upvote button is clicked', () => {
+    const firstPoster = posters[0]
+    const firstPosterId = firstPoster.id
+    let initialVotes
+
+    cy.intercept('PATCH', `https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies/${firstPosterId}`, { statusCode: 200, body: firstPoster })
+    .as('updateMovieVotes')
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteCount')
+    .invoke('text')
+    .then((text) => [
+      initialVotes = parseInt(text)
+    ])
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteButton:last').click()
+
+    cy.wait('@updateMovieVotes')
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteCount')
+    .should('be.visible')
+    .and(($el) => {
+      const updatedVotes = parseInt($el.text())
+      expect(updatedVotes).to.equal(initialVotes + 1)
+    })   
+  })
+
+  it('correctly decrements movie vote count when downvote button is clicked', () => {
+    const firstPoster = posters[0]
+    const firstPosterId = firstPoster.id
+    let initialVotes
+
+    cy.intercept('PATCH', `https://rancid-tomatillos-api-ce4a3879078e.herokuapp.com/api/v1/movies/${firstPosterId}`, { statusCode: 200, body: firstPoster })
+    .as('updateMovieVotes')
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteCount')
+    .invoke('text')
+    .then((text) => [
+      initialVotes = parseInt(text)
+    ])
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteButton:first').click()
+
+    cy.wait('@updateMovieVotes')
+
+    cy.get('.MoviesContainer .MoviePoster:first .VoteCount')
+    .should('be.visible')
+    .and(($el) => {
+      const updatedVotes = parseInt($el.text())
+      expect(updatedVotes).to.equal(initialVotes - 1)
+    }) 
   })
 })

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,5 +1,5 @@
 import './App.css';
-import searchIcon from '../icons/search.png';
+// import searchIcon from '../icons/search.png';
 import homeIcon from '../icons/home.png'
 
 // Example imports (for later):


### PR DESCRIPTION
Type of change

  - [ x ] New feature
  - [ ] Bug Fix

Check the correct boxes

  - [ x ] This code broke nothing
  - [ ] This code broke some stuff
  - [ ] This code broke everything

Implements/Fixes:

  - This branch contains completed Cypress testing for iterations 1 and 2 of the project. It verifies the user journey of arriving on the main page of the site, seeing a container of movie posters with accompanying vote counts, and being able to visually increment and decrement a movie's votes using the provided vote buttons. All tests are included in a single main.cy.js file in the cypress/e2e folder, but this will probably be split up once we get into Router refactoring.

Testing Changes:

  - [ x ] I have fully tested my code 
  - [ x ] All tests are passing
  - [ ] Some tests are failing
  - [ ] All tests are failing

  - [ x ] No previous tests have been changed
  - [ ] Some previous tests have been changed
  - [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

Checklist:

  - [ x ] I have reviewed my code
  - [ x ] The code will run locally
  - [ ] My code has no unused/commented out code
  - [ ] I have commented my code, particularly in hard-to-understand areas

(Optional) What questions do you have? Anything specific you want feedback on?

  *  I forgot to make commits throughout the process of working on these tests, and ended up just putting everything into a single commit once I was finished. Apologies.

(For Fun!) Please include a link to a gif [or add an emoji] of your feelings about this branch.

Link:
